### PR TITLE
Updates service.yml with port specification

### DIFF
--- a/template/{{serviceRole}}/service.yml
+++ b/template/{{serviceRole}}/service.yml
@@ -21,6 +21,7 @@ docker:
   ports:
 
 development:
+  port: 3000
   scripts:
     # the command to boot up the service
     run: node ./index.js


### PR DESCRIPTION
Exosphere may have outran this template. In performing the tutorial for Exosphere, I noticed port 3000 wasn't being mapped on my host to the `web-service`. I'm not sure if it's desired that the user should set this manually or if it should add it's own default port in the service.